### PR TITLE
`--start` and `--end`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # credit
 
+## Unreleased
+
+#### Added
+
+- New `--start` and `--end` options for `repo` that will only consider
+  contributions/comments between the given dates.
+
 ## 1.0.0 (2020-06-27)
 
 #### Added

--- a/src/github.rs
+++ b/src/github.rs
@@ -210,8 +210,14 @@ fn issues_work(
     let info = page.page_info;
     let mut issues: Vec<Issue> = page.edges.into_iter().map(|n| n.node).collect();
 
+    // If the user supplied `--end`, we don't need to page past the point
+    // they're looking for.
+    let stop_early = end
+        .and_then(|e| issues.last().map(|i| i.created_at > e))
+        .unwrap_or(false);
+
     match info.end_cursor {
-        Some(c) if info.has_next_page => {
+        Some(c) if info.has_next_page && !stop_early => {
             let mut next = issues_work(client, end, mode, owner, repo, Some(&c))?;
             issues.append(&mut next);
             Ok(issues)

--- a/src/github.rs
+++ b/src/github.rs
@@ -180,15 +180,17 @@ fn issue_query(mode: &Mode, owner: &str, repo: &str, page: Option<&str>) -> Stri
 /// Fetch all Issues or Pull Requests for a project, depending on the `Mode` given.
 pub fn issues(
     client: &HttpClient,
+    end: &Option<DateTime<Utc>>,
     mode: &Mode,
     owner: &str,
     repo: &str,
 ) -> anyhow::Result<Vec<Issue>> {
-    issues_work(client, mode, owner, repo, None)
+    issues_work(client, end, mode, owner, repo, None)
 }
 
 fn issues_work(
     client: &HttpClient,
+    end: &Option<DateTime<Utc>>,
     mode: &Mode,
     owner: &str,
     repo: &str,
@@ -210,7 +212,7 @@ fn issues_work(
 
     match info.end_cursor {
         Some(c) if info.has_next_page => {
-            let mut next = issues_work(client, mode, owner, repo, Some(&c))?;
+            let mut next = issues_work(client, end, mode, owner, repo, Some(&c))?;
             issues.append(&mut next);
             Ok(issues)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn repo(r: Repo) -> anyhow::Result<String> {
         let (bads, goods): (Vec<_>, Vec<_>) = spinners
             .par_iter()
             .map(|(ipb, ppb, owner, repo)| {
-                credit::repo_threads(&c, &ipb, &ppb, r.serial, r.start, r.end, &owner, &repo)
+                credit::repo_threads(&c, &ipb, &ppb, r.serial, &r.start, &r.end, &owner, &repo)
             })
             .partition_map(From::from);
 


### PR DESCRIPTION
This PR allows the results of `repo` to be time-boxed.